### PR TITLE
Disable f5 temp report

### DIFF
--- a/server/controllers/reportsController.js
+++ b/server/controllers/reportsController.js
@@ -53,13 +53,14 @@ module.exports = function reportsController(sensorsService, reportsService, temp
 
   async function reportDetails(req, res) {
     // TODO
-    const reportId = req.params.reportId;
-    const report = await reportsService.getReport(reportId);
-
-
-    if (req.query.format === 'json') {
-      res.json(report);
-    } else {
+    try {
+      const reportId = req.params.reportId;
+      const report = await reportsService.getReport(reportId);
+      // raise error if report only has now key and rescrue with catch block
+      (req.query.format === 'json') ? res.json(report) : res.render('report', { report });
+    }
+    catch (e) {
+      const report = await reportsService.lastReport();
       res.render('report', { report });
     }
   }

--- a/server/controllers/reportsController.js
+++ b/server/controllers/reportsController.js
@@ -52,15 +52,13 @@ module.exports = function reportsController(sensorsService, reportsService, temp
   }
 
   async function reportDetails(req, res) {
-    // TODO
-    try {
-      const reportId = req.params.reportId;
-      const report = await reportsService.getReport(reportId);
-      // raise error if report only has now key and rescrue with catch block
+    const reportId = req.params.reportId;
+    let report = await reportsService.getReport(reportId);
+
+    if(reportsService.tempReportInProgress()) {
       (req.query.format === 'json') ? res.json(report) : res.render('report', { report });
-    }
-    catch (e) {
-      const report = await reportsService.lastReport();
+    } else {
+      report = await reportsService.lastReport();
       res.render('report', { report });
     }
   }

--- a/server/repositories/reportsRepository.js
+++ b/server/repositories/reportsRepository.js
@@ -7,7 +7,8 @@ module.exports = function reportsRepository(Report, Medition) {
     saveReport,
     getReport,
     listForSimulations,
-    getMedition
+    getMedition,
+    last
   };
 
   async function del(reportId) {
@@ -78,5 +79,14 @@ module.exports = function reportsRepository(Report, Medition) {
       raw: false
     });
     return medition.toJSON();
+  }
+
+  async function last() {
+    const lastReport = await Report.findAll({
+      limit: 1,
+      order: [['id', 'DESC']],
+      include: [{ model: Medition, as: 'meditions' }]
+    }).map(report => report.get({ plain: true }));
+    return lastReport[0];
   }
 };

--- a/server/services/reportsService.js
+++ b/server/services/reportsService.js
@@ -19,7 +19,8 @@ module.exports = function reportsService(
     getMedition,
     del,
     eraseTemp,
-    isTemp
+    isTemp,
+    lastReport
   };
 
   function eraseTemp() {
@@ -188,5 +189,9 @@ module.exports = function reportsService(
 
   async function getMedition(meditionId) {
     return reportsRepository.getMedition(meditionId);
+  }
+
+  async function lastReport() {
+    return reportsRepository.last();
   }
 };


### PR DESCRIPTION
## Summary

* When finish report delete it from memory
* If user refresh page with /temp endpoint and without report in progress return last created report